### PR TITLE
TD-4372: Update port 1.6.4 timeouts  for backup and execution processes

### DIFF
--- a/app/recurring_job.go
+++ b/app/recurring_job.go
@@ -41,8 +41,8 @@ const (
 	WaitInterval              = 5 * time.Second
 	DetachingWaitInterval     = 10 * time.Second
 	VolumeAttachTimeout       = 300 // 5 minutes
-	BackupProcessStartTimeout = 90  // 1.5 minutes
-	SnapshotReadyTimeout      = 390 // 6.5 minutes
+	BackupProcessStartTimeout = 300 // 1.5 minutes
+	SnapshotReadyTimeout      = 600 // 6.5 minutes
 )
 
 type Job struct {

--- a/engineapi/backups.go
+++ b/engineapi/backups.go
@@ -130,7 +130,7 @@ func (btc *BackupTargetClient) ExecuteEngineBinary(args ...string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	return lhexec.NewExecutor().Execute(envs, btc.LonghornEngineBinary(), args, lhtypes.BackupDefaultTimeout)
+	return lhexec.NewExecutor().Execute(envs, btc.LonghornEngineBinary(), args, lhtypes.ExecuteDefaultTimeout)
 }
 
 func (btc *BackupTargetClient) ExecuteEngineBinaryWithTimeout(timeout time.Duration, args ...string) (string, error) {

--- a/vendor/github.com/longhorn/backupstore/util/util.go
+++ b/vendor/github.com/longhorn/backupstore/util/util.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	cmdTimeout = time.Minute * 5 // five minute by default
+	cmdTimeout = time.Minute * 20 // five minute by default
 
 	forceCleanupMountTimeout = 60 * time.Second
 )

--- a/vendor/github.com/longhorn/go-common-libs/types/exec.go
+++ b/vendor/github.com/longhorn/go-common-libs/types/exec.go
@@ -11,6 +11,5 @@ const (
 
 const (
 	ExecuteNoTimeout      = time.Duration(-1)
-	ExecuteDefaultTimeout = time.Minute * 5
-	BackupDefaultTimeout  = time.Minute * 30
+	ExecuteDefaultTimeout = time.Minute * 20
 )


### PR DESCRIPTION
Changes: 
- Increased BackupProcessStartTimeout from 90 to 300 seconds.
- Increased SnapshotReadyTimeout from 390 to 600 seconds.
- Updated ExecuteDefaultTimeout from 5 minutes to 20 minutes.
- Adjusted cmdTimeout from 5 minutes to 20 minutes for consistency across the codebase.

Updates based on https://github.com/TykTechnologies/longhorn-manager/commit/b88d36c68d9f2604d9c37f586f1a8e97df5af659
